### PR TITLE
Fix node-monitoring service start issue

### DIFF
--- a/node_monitoring/requirements.txt
+++ b/node_monitoring/requirements.txt
@@ -2,6 +2,5 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-collectd
 Jinja2
 ansible

--- a/node_monitoring/tendrl-node-monitoring.spec
+++ b/node_monitoring/tendrl-node-monitoring.spec
@@ -13,6 +13,7 @@ BuildRequires: python-mock
 
 Requires: ansible
 Requires: collectd
+Requires: python-gevent
 Requires: python-jinja2
 Requires: tendrl-commons
 


### PR DESCRIPTION
Add python-gevent dependency
Remove collectd from requirements.txt file

Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>