### PR TITLE
Packaging: fix service start issue due to package not found

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 def extract_requirements(filename):
     with open(filename, 'r') as requirements_file:
         return [
-            x[:-1] for x in requirements_file.readlines()
+            x.strip() for x in requirements_file.readlines()
             if not x.startswith("#") and x[:-1] != ''
         ]
 


### PR DESCRIPTION
setup.py fetches content of requirements.txt and omits the
last character if the file does not ends with new line.
This causes DistributionNotFound error if the requirements.txt
file does not ends with a new line.

This patch fixes this issue by just strip out the unnecessary
space and newline only if it exists.

tendrl-bug-id: Tendrl/performance-monitoring#58
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>