### PR TITLE
Fixes

### DIFF
--- a/tendrl/performance_monitoring/aggregator/cluster_summary.py
+++ b/tendrl/performance_monitoring/aggregator/cluster_summary.py
@@ -101,6 +101,8 @@ class ClusterSummarise(multiprocessing.Process):
                     cluster_summaries,
                     clusters
                 )
+            except EtcdKeyNotFound:
+                pass
             except Exception as ex:
                 Event(
                     ExceptionMessage(

--- a/tendrl/performance_monitoring/aggregator/cluster_summary.py
+++ b/tendrl/performance_monitoring/aggregator/cluster_summary.py
@@ -1,6 +1,5 @@
 from etcd import EtcdKeyNotFound
-import multiprocessing
-import time
+import gevent
 from tendrl.commons.event import Event
 from tendrl.commons.message import ExceptionMessage
 from tendrl.performance_monitoring.objects.cluster_summary \
@@ -9,10 +8,10 @@ from tendrl.performance_monitoring.sds import SDSMonitoringManager
 from tendrl.performance_monitoring.utils import read as etcd_read
 
 
-class ClusterSummarise(multiprocessing.Process):
+class ClusterSummarise(gevent.greenlet.Greenlet):
     def __init__(self):
         super(ClusterSummarise, self).__init__()
-        self._complete = multiprocessing.Event()
+        self._complete = gevent.event.Event()
         self.sds_monitoring_manager = SDSMonitoringManager()
 
     def parse_host_count(self, cluster_nodes):
@@ -87,12 +86,13 @@ class ClusterSummarise(multiprocessing.Process):
             cluster_id=cluster_id,
         )
 
-    def run(self):
+    def _run(self):
         while not self._complete.is_set():
             cluster_summaries = []
             try:
                 clusters = etcd_read('/clusters')
                 for clusterid, cluster_det in clusters.iteritems():
+                    gevent.sleep(0.1)
                     cluster_summary = self.parse_cluster(clusterid,
                                                          cluster_det)
                     cluster_summary.save(update=False)
@@ -114,7 +114,7 @@ class ClusterSummarise(multiprocessing.Process):
                             }
                     )
                 )
-            time.sleep(60)
+            gevent.sleep(60)
 
     def stop(self):
         self._complete.set()

--- a/tendrl/performance_monitoring/aggregator/node_summary.py
+++ b/tendrl/performance_monitoring/aggregator/node_summary.py
@@ -212,7 +212,7 @@ class NodeSummarise(multiprocessing.Process):
             alert_count
         )
         try:
-            summary.save()
+            summary.save(update=False)
         except Exception as ex:
             Event(
                 ExceptionMessage(

--- a/tendrl/performance_monitoring/aggregator/node_summary.py
+++ b/tendrl/performance_monitoring/aggregator/node_summary.py
@@ -3,9 +3,7 @@ from etcd import EtcdConnectionFailed
 from etcd import EtcdKeyNotFound
 import gevent
 import math
-import multiprocessing
 import re
-import time
 
 from tendrl.commons.event import Event
 from tendrl.commons.message import ExceptionMessage
@@ -16,10 +14,10 @@ from tendrl.performance_monitoring.objects.node_summary \
     import NodeSummary
 
 
-class NodeSummarise(multiprocessing.Process):
+class NodeSummarise(gevent.greenlet.Greenlet):
     def __init__(self):
         super(NodeSummarise, self).__init__()
-        self._complete = multiprocessing.Event()
+        self._complete = gevent.event.Event()
 
     ''' Get latest stats of resource as in param resource'''
     def get_latest_stat(self, node, resource):
@@ -156,7 +154,7 @@ class NodeSummarise(multiprocessing.Process):
             return 0
 
     def calculate_host_summary(self, node):
-        gevent.sleep(1)
+        gevent.sleep(0.1)
         cpu_usage = self.get_net_host_cpu_utilization(node)
         memory_usage = self.get_net_host_memory_utilization(node)
         storage_usage = self.get_net_storage_utilization(node)
@@ -229,11 +227,12 @@ class NodeSummarise(multiprocessing.Process):
         nodes = NS.central_store_thread.get_node_ids()
         for node in nodes:
             gevent.spawn(self.calculate_host_summary, node)
+            gevent.sleep(0.1)
 
-    def run(self):
+    def _run(self):
         while not self._complete.is_set():
             self.calculate_host_summaries()
-            time.sleep(60)
+            gevent.sleep(60)
 
     def stop(self):
         self._complete.set()

--- a/tendrl/performance_monitoring/configure/configure_cluster_monitoring.py
+++ b/tendrl/performance_monitoring/configure/configure_cluster_monitoring.py
@@ -1,15 +1,13 @@
 import gevent
-import multiprocessing
-import time
 
 from tendrl.performance_monitoring.sds import SDSMonitoringManager
 from tendrl.performance_monitoring.utils import initiate_config_generation
 
 
-class ConfigureClusterMonitoring(multiprocessing.Process):
+class ConfigureClusterMonitoring(gevent.greenlet.Greenlet):
     def __init__(self):
         super(ConfigureClusterMonitoring, self).__init__()
-        self._complete = multiprocessing.Event()
+        self._complete = gevent.event.Event()
         self.sds_monitoring_manager = SDSMonitoringManager()
 
     def get_cluster_ids(self):
@@ -41,9 +39,9 @@ class ConfigureClusterMonitoring(multiprocessing.Process):
                             gevent.spawn(initiate_config_generation, config)
             except Exception:
                 pass
-            time.sleep(10)
+            gevent.sleep(10)
 
-    def run(self):
+    def _run(self):
         self.configure_cluster_monitoring()
 
     def stop(self):

--- a/tendrl/performance_monitoring/configure/configure_cluster_monitoring.py
+++ b/tendrl/performance_monitoring/configure/configure_cluster_monitoring.py
@@ -1,4 +1,3 @@
-from etcd import EtcdKeyNotFound
 import gevent
 import multiprocessing
 import time
@@ -25,7 +24,7 @@ class ConfigureClusterMonitoring(multiprocessing.Process):
                     cluster_id = key_contents[2]
                     cluster_ids.append(cluster_id)
             return cluster_ids
-        except EtcdKeyNotFound:
+        except Exception:
             return cluster_ids
 
     def configure_cluster_monitoring(self):

--- a/tendrl/performance_monitoring/configure/configure_node_monitoring.py
+++ b/tendrl/performance_monitoring/configure/configure_node_monitoring.py
@@ -2,7 +2,6 @@ import ast
 from etcd import EtcdConnectionFailed
 import gevent.event
 import gevent.greenlet
-import time
 
 from tendrl.commons.event import Event
 from tendrl.commons.message import ExceptionMessage
@@ -99,7 +98,7 @@ class ConfigureNodeMonitoring(gevent.greenlet.Greenlet):
             while not self._complete.is_set():
                 gevent.sleep(0.1)
                 self.init_monitoring()
-                time.sleep(10)
+                gevent.sleep(10)
         except (EtcdConnectionFailed, Exception) as e:
             Event(
                 ExceptionMessage(

--- a/tendrl/performance_monitoring/configure/configure_node_monitoring.py
+++ b/tendrl/performance_monitoring/configure/configure_node_monitoring.py
@@ -2,8 +2,8 @@ import ast
 from etcd import EtcdConnectionFailed
 import gevent.event
 import gevent.greenlet
+import time
 
-from tendrl.commons import etcdobj
 from tendrl.commons.event import Event
 from tendrl.commons.message import ExceptionMessage
 from tendrl.performance_monitoring.exceptions \
@@ -24,13 +24,6 @@ class ConfigureNodeMonitoring(gevent.greenlet.Greenlet):
                     self.monitoring_config_init_nodes.append(
                         node_det['node_id']
                     )
-            etcd_kwargs = {
-                'port': int(
-                    NS.performance_monitoring.config.data['etcd_port']),
-                'host': NS.performance_monitoring.config.data[
-                    "etcd_connection"]
-            }
-            self.etcd_orm = etcdobj.Server(etcd_kwargs=etcd_kwargs)
         except TendrlPerformanceMonitoringException as ex:
             Event(
                 ExceptionMessage(
@@ -97,7 +90,6 @@ class ConfigureNodeMonitoring(gevent.greenlet.Greenlet):
         super(ConfigureNodeMonitoring, self).__init__()
         try:
             self.monitoring_config_init_nodes = []
-            self.init_monitoring()
             self._complete = gevent.event.Event()
         except TendrlPerformanceMonitoringException as ex:
             raise ex
@@ -105,27 +97,9 @@ class ConfigureNodeMonitoring(gevent.greenlet.Greenlet):
     def _run(self):
         try:
             while not self._complete.is_set():
-                gevent.sleep(1)
-                node_changes = self.etcd_orm.client.watch(
-                    '/nodes', recursive=True, timeout=0)
-                if node_changes is not None and node_changes.value is not None:
-                    node_id = node_changes.key
-                    if node_changes.key.startswith('/nodes/') \
-                            and node_changes.key.endswith(
-                                '/NodeContext/fqdn'):
-                        nodeid_pre_trim = node_id[len('/nodes/'):]
-                        node_id = nodeid_pre_trim[: -len('/NodeContext/fqdn')]
-                        fqdn = node_changes.value
-                        if node_id not in self.monitoring_config_init_nodes:
-                            gevent.sleep(0.1)
-                            gevent.spawn(
-                                self.init_monitoring_on_node,
-                                {
-                                    'node_id': node_id,
-                                    'fqdn': fqdn
-                                }
-                            )
-                            self.monitoring_config_init_nodes.append(node_id)
+                gevent.sleep(0.1)
+                self.init_monitoring()
+                time.sleep(10)
         except (EtcdConnectionFailed, Exception) as e:
             Event(
                 ExceptionMessage(

--- a/tendrl/performance_monitoring/manager/__init__.py
+++ b/tendrl/performance_monitoring/manager/__init__.py
@@ -186,6 +186,7 @@ class TendrlPerformanceManager(object):
             raise
 
     def start(self):
+        NS.central_store_thread.start()
         self.node_summariser.start()
         self.cluster_summariser.start()
         self.configure_cluster_monitoring.start()
@@ -206,6 +207,7 @@ class TendrlPerformanceManager(object):
             self.stop()
 
     def stop(self):
+        NS.central_store_thread.stop()
         self.configure_cluster_monitoring.stop()
         self.configure_node_monitoring.stop()
         NS.configurator_queue.close()

--- a/tendrl/performance_monitoring/sds/__init__.py
+++ b/tendrl/performance_monitoring/sds/__init__.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod
 import ast
+from etcd import EtcdKeyNotFound
 import importlib
 import inspect
 import os
@@ -194,6 +195,8 @@ class SDSMonitoringManager(object):
             sds_tendrl_context = etcd_read_key(
                 'clusters/%s/TendrlContext' % integration_id
             )
+        except EtcdKeyNotFound:
+            return None
         except Exception as ex:
             Event(
                 ExceptionMessage(

--- a/tendrl/performance_monitoring/time_series_db/dbplugins/graphite.py
+++ b/tendrl/performance_monitoring/time_series_db/dbplugins/graphite.py
@@ -1,5 +1,5 @@
 import ast
-import time
+import gevent
 import urllib3
 
 from tendrl.commons.event import Event
@@ -54,7 +54,7 @@ class GraphitePlugin(TimeSeriesDBPlugin):
     def get_metrics(self, entity_name):
         url = 'http://%s:%s/metrics/index.json' % (self.host, str(self.port))
         try:
-            time.sleep(5)
+            gevent.sleep(5)
             resp = self.http.request('GET', url, timeout=5)
             if resp.status != 200:
                 raise TendrlPerformanceMonitoringException(

--- a/tendrl/performance_monitoring/utils/__init__.py
+++ b/tendrl/performance_monitoring/utils/__init__.py
@@ -36,7 +36,9 @@ def initiate_config_generation(node_det):
             'type': 'monitoring',
             "parameters": {
                 'plugin_name': node_det['plugin'],
-                'plugin_conf_params': json.dumps(node_det['plugin_conf']),
+                'plugin_conf_params': json.dumps(
+                    node_det['plugin_conf']
+                ).encode('utf-8'),
                 'Node.fqdn': node_det['fqdn'],
                 'Service.name': 'collectd',
             },
@@ -44,7 +46,7 @@ def initiate_config_generation(node_det):
         Job(
             job_id=str(uuid.uuid4()),
             status='new',
-            payload=json.dumps(job_params),
+            payload=json.dumps(job_params).encode('utf-8'),
         ).save()
     except (EtcdException, EtcdConnectionFailed, Exception) as ex:
         raise TendrlPerformanceMonitoringException(


### PR DESCRIPTION
This pr fixes the following:
1. Modified cluster_summary to not raise any exception if there is no cluster
   which is expected instead of raising exception.
2. Node summary calculates summary periodically and an update of this to etcd
   should compulsorily override the previously stored summary hence changed it to
   pass update=False at the time of invoking save
3. Change ConfigureNodeMonitoring to periodically check /nodes instead of watching
   it. The reason for tis is
   1. If /nodes is watched recursively, any and every sync time change to any key
      under /nodes/{node-id} is seen as a change in /nodes and hence adding a lot
      of latency(that grows as a measure of no. of nodes) to configuration of
      collectd on newly managed nodes.
   2. If /nodes is not watched recursively, there are chances of missing out
      configuration of some of the nodes if they are managed at relatively same
      time.

Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>