### PR TITLE
Object load in loop loads objects with some details same

### DIFF
--- a/tendrl/performance_monitoring/central_store/__init__.py
+++ b/tendrl/performance_monitoring/central_store/__init__.py
@@ -190,9 +190,9 @@ class PerformanceMonitoringEtcdCentralStore(central_store.EtcdCentralStore):
             node_ids = self.get_node_ids()
         for node_id in node_ids:
             try:
-                current_node_summary = NodeSummary(
-                    node_id=node_id
-                ).load().to_json()
+                current_node_summary = etcd_read(
+                    '/monitoring/summary/nodes/%s' % node_id
+                )
                 if '_etcd_cls' in current_node_summary:
                     del current_node_summary['_etcd_cls']
                 if 'value' in current_node_summary:


### PR DESCRIPTION
Multiple object load is causing issues it is retaining some
fields same for all objects. Hence reverting to use the read
utility

Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>