### PR TITLE
Add osd near full count and fix swings in gluster main dashboard

### DIFF
--- a/tendrl/performance_monitoring/sds/__init__.py
+++ b/tendrl/performance_monitoring/sds/__init__.py
@@ -154,31 +154,32 @@ class SDSPlugin(object):
                     ) / (
                         net_utilization['total'] * 1.0
                     )
+        if net_utilization['total']:
         # Push the computed system utilization to time-series db
-        NS.time_series_db_manager.get_plugin().push_metrics(
-            NS.time_series_db_manager.get_timeseriesnamefromresource(
-                sds_type=self.name,
-                utilization_type=pm_consts.TOTAL,
-                resource_name=pm_consts.SYSTEM_UTILIZATION
-            ),
-            net_utilization[pm_consts.TOTAL]
-        )
-        NS.time_series_db_manager.get_plugin().push_metrics(
-            NS.time_series_db_manager.get_timeseriesnamefromresource(
-                sds_type=self.name,
-                utilization_type=pm_consts.USED,
-                resource_name=pm_consts.SYSTEM_UTILIZATION
-            ),
-            net_utilization[pm_consts.USED]
-        )
-        NS.time_series_db_manager.get_plugin().push_metrics(
-            NS.time_series_db_manager.get_timeseriesnamefromresource(
-                sds_type=self.name,
-                utilization_type=pm_consts.PERCENT_USED,
-                resource_name=pm_consts.SYSTEM_UTILIZATION
-            ),
-            net_utilization[pm_consts.PERCENT_USED]
-        )
+            NS.time_series_db_manager.get_plugin().push_metrics(
+                NS.time_series_db_manager.get_timeseriesnamefromresource(
+                    sds_type=self.name,
+                    utilization_type=pm_consts.TOTAL,
+                    resource_name=pm_consts.SYSTEM_UTILIZATION
+                ),
+                net_utilization[pm_consts.TOTAL]
+            )
+            NS.time_series_db_manager.get_plugin().push_metrics(
+                NS.time_series_db_manager.get_timeseriesnamefromresource(
+                    sds_type=self.name,
+                    utilization_type=pm_consts.USED,
+                    resource_name=pm_consts.SYSTEM_UTILIZATION
+                ),
+                net_utilization[pm_consts.USED]
+            )
+            NS.time_series_db_manager.get_plugin().push_metrics(
+                NS.time_series_db_manager.get_timeseriesnamefromresource(
+                    sds_type=self.name,
+                    utilization_type=pm_consts.PERCENT_USED,
+                    resource_name=pm_consts.SYSTEM_UTILIZATION
+                ),
+                net_utilization[pm_consts.PERCENT_USED]
+            )
         return net_utilization
 
     def get_system_host_status_wise_counts(self, cluster_summaries):

--- a/tendrl/performance_monitoring/sds/ceph/ceph_plugin.py
+++ b/tendrl/performance_monitoring/sds/ceph/ceph_plugin.py
@@ -236,7 +236,8 @@ class CephPlugin(SDSPlugin):
             'total': 0,
             'down': 0,
             pm_consts.CRITICAL_ALERTS: 0,
-            pm_consts.WARNING_ALERTS: 0
+            pm_consts.WARNING_ALERTS: 0,
+            'near_full': 0
         }
         if 'maps' in cluster_det:
             osds = ast.literal_eval(
@@ -262,6 +263,13 @@ class CephPlugin(SDSPlugin):
                 {}
             ).get('integration_id', '')
         )
+        for osd_alert in crit_alerts:
+            if (
+                osd_alert['severity'] == pm_consts.CRITICAL and
+                osd_alert['resource'] == 'osd_utilization'
+            ):
+                osd_status_wise_counts['near_full'] = \
+                    osd_status_wise_counts.get('near_full', 0) + 1
         osd_status_wise_counts[
             pm_consts.CRITICAL_ALERTS
         ] = len(crit_alerts)


### PR DESCRIPTION
1. Add osd near full count
2. fix swings in gluster main dashboard that occured due to gstatus
   erroring out sometimes(when repeatedly executed) and hence backend
   sync changes the value to empty string which is treated by
   performance-monitoring as 0. The fix now checks if total is 0 and in
   which case does not push the system utilization at all.

Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>