### PR TITLE
Fix unwanted re-generation of collectd plugins

### DIFF
--- a/tendrl/performance_monitoring/configure/configure_node_monitoring.py
+++ b/tendrl/performance_monitoring/configure/configure_node_monitoring.py
@@ -17,14 +17,7 @@ class ConfigureNodeMonitoring(gevent.greenlet.Greenlet):
         try:
             node_dets = central_store_util.get_nodes_details()
             for node_det in node_dets:
-                if (
-                    node_det['node_id'] not in
-                    self.monitoring_config_init_nodes
-                ):
-                    self.init_monitoring_on_node(node_det)
-                    self.monitoring_config_init_nodes.append(
-                        node_det['node_id']
-                    )
+                self.init_monitoring_on_node(node_det)
         except TendrlPerformanceMonitoringException as ex:
             Event(
                 ExceptionMessage(
@@ -56,6 +49,9 @@ class ConfigureNodeMonitoring(gevent.greenlet.Greenlet):
             }
         )
         gevent.sleep(0.1)
+        time_series_db_server = NS.performance_monitoring.config.data[
+            'time_series_db_server'
+        ]
         initiate_config_generation(
             {
                 'node_id': node_det['node_id'],
@@ -65,7 +61,8 @@ class ConfigureNodeMonitoring(gevent.greenlet.Greenlet):
                     'master_name': NS.performance_monitoring.config.data[
                         'master_name'],
                     'interval': NS.performance_monitoring.config.data[
-                        'interval']
+                        'interval'],
+                    'time_series_db_server': time_series_db_server
                 }
             }
         )
@@ -116,7 +113,6 @@ class ConfigureNodeMonitoring(gevent.greenlet.Greenlet):
     def __init__(self):
         super(ConfigureNodeMonitoring, self).__init__()
         try:
-            self.monitoring_config_init_nodes = []
             self._complete = gevent.event.Event()
         except TendrlPerformanceMonitoringException as ex:
             raise ex

--- a/tendrl/performance_monitoring/objects/definition/performance_monitoring.yaml
+++ b/tendrl/performance_monitoring/objects/definition/performance_monitoring.yaml
@@ -67,4 +67,18 @@ namespace.performance_monitoring:
       value: monitoring/summary/system/$SystemSummary.sds_type
       list: monitoring/summary/system
       help: "System Summary"
+    NodeMonitoringPlugin:
+      attrs:
+        plugin_name:
+          type: String
+        node_id:
+          type: String
+        job_id:
+          type: String
+        time_stamp:
+          type: String
+      enabled: true
+      value: monitoring/plugin_configurations/nodes/$NodeMonitoringPlugin.node_id/$NodeMonitoringPlugin.plugin_name
+      list: monitoring/plugin_configurations/nodes/$NodeMonitoringPlugin.node_id
+      help: "Monitoring plugin configurations on node"
 tendrl_schema_version: 0.3

--- a/tendrl/performance_monitoring/objects/node_monitoring_plugin/__init__.py
+++ b/tendrl/performance_monitoring/objects/node_monitoring_plugin/__init__.py
@@ -1,0 +1,34 @@
+from tendrl.commons import objects
+from tendrl.commons.utils.time_utils import now
+
+
+class NodeMonitoringPlugin(objects.BaseObject):
+    def __init__(
+        self,
+        plugin_name=None,
+        node_id=None,
+        job_id='',
+        time_stamp=str(now()),
+        *args,
+        **kwargs
+    ):
+        # TODO(anmol_b): Add status to track configuration status and retrial
+        # count if auto-retrials are required. node-monitoring which is the
+        # consumer of these monitoring configuration jobs, will update success
+        # or failure in configuration when the job is picked by it. And retrial
+        # counter would be incremented from the only supposed way to load
+        # monitoring utils#util#initiate_config_generation jobs to /queue.
+        # There unpicked timed-out jobs can then be updated from configuration
+        # threads - configure_node_monitoiring and configure_cluster_monitoring
+        # before deciding to attempt/re-attempt config generation by looking at
+        # job's' status using the job_id here..
+        super(NodeMonitoringPlugin, self).__init__(*args, **kwargs)
+        self.node_id = node_id
+        self.plugin_name = plugin_name
+        self.job_id = job_id
+        self.time_stamp = time_stamp
+        self.value = 'monitoring/plugin_configurations/nodes/{0}/{1}'
+
+    def render(self):
+        self.value = self.value.format(self.node_id, self.plugin_name)
+        return super(NodeMonitoringPlugin, self).render()

--- a/tendrl/performance_monitoring/sds/ceph/ceph_plugin.py
+++ b/tendrl/performance_monitoring/sds/ceph/ceph_plugin.py
@@ -1,4 +1,5 @@
 import ast
+import copy
 from etcd import EtcdKeyNotFound
 import json
 from tendrl.commons.event import Event
@@ -53,13 +54,14 @@ class CephPlugin(SDSPlugin):
                         plugin_config = ast.literal_eval(
                             plugin_config.encode('ascii', 'ignore')
                         )
-                    plugin_config['cluster_id'] = \
+                    p_conf = copy.deepcopy(plugin_config)
+                    p_conf['cluster_id'] = \
                         sds_tendrl_context['integration_id']
-                    plugin_config['cluster_name'] = \
+                    p_conf['cluster_name'] = \
                         sds_tendrl_context['cluster_name']
                     configs.append({
                         'plugin': "tendrl_%s_%s" % (self.name, plugin),
-                        'plugin_conf': plugin_config,
+                        'plugin_conf': p_conf,
                         'node_id': node_id,
                         'fqdn': sds_node_context['fqdn']
                     })

--- a/tendrl/performance_monitoring/sds/ceph/ceph_plugin.py
+++ b/tendrl/performance_monitoring/sds/ceph/ceph_plugin.py
@@ -28,7 +28,6 @@ class CephPlugin(SDSPlugin):
             'ceph-mon',
             'ceph-osd'
         ])
-        self.configured_nodes = {}
 
     def configure_monitoring(self, sds_tendrl_context):
         configs = []
@@ -54,92 +53,49 @@ class CephPlugin(SDSPlugin):
                         plugin_config = ast.literal_eval(
                             plugin_config.encode('ascii', 'ignore')
                         )
-                    is_configured = True
-                    if node_id not in self.configured_nodes:
-                        self.configured_nodes[node_id] = [
-                            "tendrl_%s_%s" % (self.name, plugin)
-                        ]
-                        is_configured = False
-                    if (
-                        "tendrl_%s_%s" % (self.name, plugin) not in
-                            self.configured_nodes.get(node_id, [])
-                    ):
-                        node_plugins = self.configured_nodes.get(node_id, [])
-                        node_plugins.append(
-                            "tendrl_%s_%s" % (self.name, plugin)
-                        )
-                        self.configured_nodes[node_id] = node_plugins
-                        is_configured = False
-                    if not is_configured:
-                        plugin_config['cluster_id'] = \
-                            sds_tendrl_context['integration_id']
-                        plugin_config['cluster_name'] = \
-                            sds_tendrl_context['cluster_name']
-                        configs.append({
-                            'plugin': "tendrl_%s_%s" % (self.name, plugin),
-                            'plugin_conf': plugin_config,
-                            'node_id': node_id,
-                            'fqdn': sds_node_context['fqdn']
-                        })
-                is_configured = True
-                if (
-                    "tendrl_ceph_cluster_iops" not in
-                        self.configured_nodes.get(node_id, [])
-                ):
-                    node_plugins = self.configured_nodes.get(node_id, [])
-                    node_plugins.append(
-                        "tendrl_ceph_cluster_iops"
-                    )
-                    self.configured_nodes[node_id] = node_plugins
-                    is_configured = False
-                if not is_configured:
-                    plugin_config = {
-                        'cluster_id': sds_tendrl_context['integration_id'],
-                        'cluster_name': sds_tendrl_context['cluster_name']
-                    }
+                    plugin_config['cluster_id'] = \
+                        sds_tendrl_context['integration_id']
+                    plugin_config['cluster_name'] = \
+                        sds_tendrl_context['cluster_name']
                     configs.append({
-                        'plugin': "tendrl_ceph_cluster_iops",
+                        'plugin': "tendrl_%s_%s" % (self.name, plugin),
                         'plugin_conf': plugin_config,
                         'node_id': node_id,
                         'fqdn': sds_node_context['fqdn']
                     })
-            is_configured = True
-            if (
-                "tendrl_ceph_node_network_throughput" not in
-                    self.configured_nodes.get(node_id, [])
-            ):
-                plugin_config = {}
-                plugin_config['cluster_network'] = ' '.join(
-                    self.get_nw_node_interfaces(
-                        node_id,
-                        'cluster_network',
-                        sds_tendrl_context['integration_id']
-                    )
+                plugin_config = {
+                    'cluster_id': sds_tendrl_context['integration_id'],
+                    'cluster_name': sds_tendrl_context['cluster_name']
+                }
+                configs.append({
+                    'plugin': "tendrl_ceph_cluster_iops",
+                    'plugin_conf': plugin_config,
+                    'node_id': node_id,
+                    'fqdn': sds_node_context['fqdn']
+                })
+            plugin_config = {}
+            plugin_config['cluster_network'] = ' '.join(
+                self.get_nw_node_interfaces(
+                    node_id,
+                    'cluster_network',
+                    sds_tendrl_context['integration_id']
                 )
-                plugin_config['public_network'] = ' '.join(
-                    self.get_nw_node_interfaces(
-                        node_id,
-                        'public_network',
-                        sds_tendrl_context['integration_id']
-                    )
+            )
+            plugin_config['public_network'] = ' '.join(
+                self.get_nw_node_interfaces(
+                    node_id,
+                    'public_network',
+                    sds_tendrl_context['integration_id']
                 )
-                if (
-                    plugin_config['cluster_network'] and
-                        plugin_config['public_network']
-                ):
-                    node_plugins = self.configured_nodes.get(node_id, [])
-                    node_plugins.append(
-                        "tendrl_ceph_node_network_throughput"
-                    )
-                    self.configured_nodes[node_id] = node_plugins
-                    configs.append({
-                        'plugin': "tendrl_%s_node_network_throughput" % (
-                            self.name
-                        ),
-                        'plugin_conf': plugin_config,
-                        'node_id': node_id,
-                        'fqdn': sds_node_context['fqdn']
-                    })
+            )
+            configs.append({
+                'plugin': "tendrl_%s_node_network_throughput" % (
+                    self.name
+                ),
+                'plugin_conf': plugin_config,
+                'node_id': node_id,
+                'fqdn': sds_node_context['fqdn']
+            })
         return configs
 
     def get_nw_node_interfaces(self, node_id, nw_type, cluster_id):

--- a/tendrl/performance_monitoring/sds/glusterfs/glusterfs_plugin.py
+++ b/tendrl/performance_monitoring/sds/glusterfs/glusterfs_plugin.py
@@ -1,4 +1,5 @@
 import ast
+import copy
 from etcd import EtcdKeyNotFound
 from tendrl.commons.event import Event
 from tendrl.commons.message import ExceptionMessage
@@ -47,13 +48,14 @@ class GlusterFSPlugin(SDSPlugin):
                     plugin_config = ast.literal_eval(
                         plugin_config.encode('ascii', 'ignore')
                     )
-                plugin_config['cluster_id'] = \
+                p_conf = copy.deepcopy(plugin_config)
+                p_conf['cluster_id'] = \
                     sds_tendrl_context['integration_id']
-                plugin_config['cluster_name'] = \
+                p_conf['cluster_name'] = \
                     sds_tendrl_context['cluster_name']
                 configs.append({
                     'plugin': "tendrl_%sfs_%s" % (self.name, plugin),
-                    'plugin_conf': plugin_config,
+                    'plugin_conf': p_conf,
                     'node_id': node_id,
                     'fqdn': sds_node_context['fqdn']
                 })

--- a/tendrl/performance_monitoring/sds/glusterfs/glusterfs_plugin.py
+++ b/tendrl/performance_monitoring/sds/glusterfs/glusterfs_plugin.py
@@ -25,7 +25,6 @@ class GlusterFSPlugin(SDSPlugin):
             'tendrl-gluster-integration',
             'glusterd'
         ])
-        self.configured_nodes = {}
 
     def configure_monitoring(self, sds_tendrl_context):
         configs = []
@@ -48,51 +47,26 @@ class GlusterFSPlugin(SDSPlugin):
                     plugin_config = ast.literal_eval(
                         plugin_config.encode('ascii', 'ignore')
                     )
-                is_configured = True
-                if node_id not in self.configured_nodes:
-                    self.configured_nodes[node_id] = [plugin]
-                    is_configured = False
-                if (
-                    "tendrl_%sfs_%s" % (self.name, plugin) not in
-                    self.configured_nodes[node_id]
-                ):
-                    node_plugins = self.configured_nodes[node_id]
-                    node_plugins.append("tendrl_%sfs_%s" % (self.name, plugin))
-                    self.configured_nodes[node_id] = node_plugins
-                    is_configured = False
-                if not is_configured:
-                    plugin_config['cluster_id'] = \
-                        sds_tendrl_context['integration_id']
-                    plugin_config['cluster_name'] = \
-                        sds_tendrl_context['cluster_name']
-                    configs.append({
-                        'plugin': "tendrl_%sfs_%s" % (self.name, plugin),
-                        'plugin_conf': plugin_config,
-                        'node_id': node_id,
-                        'fqdn': sds_node_context['fqdn']
-                    })
-            is_configured = True
-            if (
-                "%sfs_peer_network_throughput" % (self.name) not in
-                    self.configured_nodes[node_id]
-            ):
-                node_plugins = self.configured_nodes[node_id]
-                node_plugins.append(
-                    "%sfs_peer_network_throughput" % (self.name)
-                )
-                self.configured_nodes[node_id] = node_plugins
-                is_configured = False
-            if not is_configured:
+                plugin_config['cluster_id'] = \
+                    sds_tendrl_context['integration_id']
+                plugin_config['cluster_name'] = \
+                    sds_tendrl_context['cluster_name']
                 configs.append({
-                    'plugin': "tendrl_%sfs_peer_network_throughput" % (
-                        self.name
-                    ),
-                    'plugin_conf': {
-                        'peer_name': sds_node_context['fqdn']
-                    },
+                    'plugin': "tendrl_%sfs_%s" % (self.name, plugin),
+                    'plugin_conf': plugin_config,
                     'node_id': node_id,
                     'fqdn': sds_node_context['fqdn']
                 })
+            configs.append({
+                'plugin': "tendrl_%sfs_peer_network_throughput" % (
+                    self.name
+                ),
+                'plugin_conf': {
+                    'peer_name': sds_node_context['fqdn']
+                },
+                'node_id': node_id,
+                'fqdn': sds_node_context['fqdn']
+            })
         return configs
 
     def get_brick_status_wise_counts(self, cluster_id, volumes_det):


### PR DESCRIPTION
Fix unwanted re-generation of collectd plugins across performance-monitoring
restarts. Prior to this approach the nodes on which configurations are made
were stored in-memory to avoid regeneration of configurations during the next
scan through the list of clusters and nodes. But the problem with that approach
is that if performance-monitoring is restarted for any reason such as node goes
down and hence performance-monitoring was started back once the node is back up,
or for any other reason, the configurations would be regenerated as the in-memory
data about the configurations made were lost.

Hence this PR puts that in-memory state info about the configurations made to
etcd which is persisted across restarts and hence configuration regenerations
are avoided.

tendrl-bug-id: Tendrl/performance-monitoring#202
Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>