### PR TITLE
Multiple calls to objects.Definition.get_parsed_defs()

### DIFF
--- a/tendrl/performance_monitoring/objects/definition/__init__.py
+++ b/tendrl/performance_monitoring/objects/definition/__init__.py
@@ -18,5 +18,8 @@ class Definition(objects.BaseObject):
         self.value = '_NS/performance_monitoring/definitions'
 
     def get_parsed_defs(self):
+        if self._parsed_defs:
+            return self._parsed_defs
+        
         self._parsed_defs = yaml.safe_load(self.data)
         return self._parsed_defs


### PR DESCRIPTION
tendrl-bug-id: Tendrl/performance-monitoring#208